### PR TITLE
Fix name collision with docker_registry gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This is a simple gem that provides direct http access to a docker registry v2 without going through a docker server. You do **not** requires docker installed on your system to provide access.
 
 ````ruby
-reg = DockerRegistry.connect("https://my.registy.corp.com")
+reg = DockerRegistry2.connect("https://my.registy.corp.com")
 repos = reg.search("foo/repo")
 tags = reg.tags("foo/repo")
 ````
@@ -14,6 +14,14 @@ Supports anonymous access, http authorization and v2 token access.
 
 Inspired by https://github.com/rosylilly/docker_registry but written separately.
 
+#### Note
+
+Prior to version 0.4.0, the name used was DockerRegistry. As of 0.4.0 it is DockerRegistry2.
+If you still need DockerRegistry, just create an alias with:
+
+````ruby
+DockerRegistry = DockerRegistry2
+````
 
 ## Installation
 
@@ -35,7 +43,7 @@ Once it is installed, you first *open* a connection to a registry, and then *req
 To connect to a registry:
 
 ````ruby
-reg = DockerRegistry.connect("https://my.registy.corp.com")
+reg = DockerRegistry2.connect("https://my.registy.corp.com")
 ````
 
 The above will connect anonymously to the registry via the endpoint `https://my.registry.corp.com/v2/`.
@@ -50,7 +58,7 @@ The following exceptions are thrown:
 If you wish to authenticate, pass a username and password as part of the URL.
 
 ````ruby
-reg = DockerRegistry.connect("https://myuser:mypass@my.registy.corp.com")
+reg = DockerRegistry2.connect("https://myuser:mypass@my.registy.corp.com")
 ````
 
 The following exceptions are thrown:
@@ -62,7 +70,7 @@ The following exceptions are thrown:
 
 
 ### Requests
-Once you have a valid `reg` object return by `DockerRegistry.connect()`, you can make requests. As of this version, only search and tags are supported. Others will be added over time.
+Once you have a valid `reg` object return by `DockerRegistry2.connect()`, you can make requests. As of this version, only search and tags are supported. Others will be added over time.
 
 
 #### search
@@ -239,7 +247,7 @@ The following exceptions are thrown:
 
 ### Exceptions
 
-All exceptions thrown inherit from `DockerRegistry::Exception`.
+All exceptions thrown inherit from `DockerRegistry2::Exception`.
 
 ## Tests
 The simplest way to test is against a true v2 registry. Thus, the test setup and teardown work against a docker registry. That means that to test, you need a docker engine running. The tests will start up a registry (actually, two registries, to be able to test `copy()`), initialize the data and test against them.

--- a/docker_registry2.gemspec
+++ b/docker_registry2.gemspec
@@ -5,8 +5,8 @@ require 'registry/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'docker_registry2'
-  spec.version       = DockerRegistry::VERSION
-  spec.authors       = ['Avi Deitcher https://github.com/deitch', 'Jonathan Hurter https://github.com/johnsudaar']
+  spec.version       = DockerRegistry2::VERSION
+  spec.authors       = ['Avi Deitcher https://github.com/deitch', 'Jonathan Hurter https://github.com/johnsudaar', 'Dmitry Fleytman https://github.com/dmitryfleytman']
   spec.summary       = 'Docker v2 registry HTTP API client'
   spec.description   = 'Docker v2 registry HTTP API client with support for token authentication'
   spec.homepage      = 'https://github.com/deitch/docker_registry2'

--- a/lib/docker_registry2.rb
+++ b/lib/docker_registry2.rb
@@ -3,9 +3,9 @@ require File.dirname(__FILE__) + '/registry/registry'
 require File.dirname(__FILE__) + '/registry/exceptions'
 
 
-module DockerRegistry
+module DockerRegistry2
   def self.connect(uri)
-    @reg = DockerRegistry::Registry.new(uri)
+    @reg = DockerRegistry2::Registry.new(uri)
   end  
   
   def self.search(query = '')

--- a/lib/registry/exceptions.rb
+++ b/lib/registry/exceptions.rb
@@ -1,4 +1,4 @@
-module DockerRegistry
+module DockerRegistry2
   class Exception < RuntimeError
     
   end

--- a/lib/registry/registry.rb
+++ b/lib/registry/registry.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 require 'rest-client'
 require 'json'
 
-class DockerRegistry::Registry
+class DockerRegistry2::Registry
   # @param [#to_s] base_uri Docker registry base URI
   # @param [Hash] options Client options
   # @option options [#to_s] :user User name for basic authentication
@@ -53,7 +53,7 @@ class DockerRegistry::Registry
         else
           begin
             head = dohead "/v2/#{repo}/manifests/#{tag}"
-          rescue DockerRegistry::InvalidMethod
+          rescue DockerRegistry2::InvalidMethod
             # in case we are in a registry pre-2.3.0, which did not support manifest HEAD
             useGet = true
             head = doget "/v2/#{repo}/manifests/#{tag}"
@@ -104,7 +104,7 @@ class DockerRegistry::Registry
         }
         response = RestClient::Request.execute method: type, url: @base_uri+url, headers: {Accept: 'application/vnd.docker.distribution.manifest.v2+json'}, block_response: block
       rescue SocketError
-        raise DockerRegistry::RegistryUnknownException
+        raise DockerRegistry2::RegistryUnknownException
       rescue RestClient::Unauthorized => e
         header = e.response.headers[:www_authenticate]
         method = header.downcase.split(' ')[0]
@@ -114,7 +114,7 @@ class DockerRegistry::Registry
         when 'bearer'
           response = do_bearer_req(type, url, header, stream)
         else
-          raise DockerRegistry::RegistryUnknownException
+          raise DockerRegistry2::RegistryUnknownException
         end
       end
       return response
@@ -129,11 +129,11 @@ class DockerRegistry::Registry
         }
         response = RestClient::Request.execute method: type, url: @base_uri+url, user: @user, password: @password, headers: {Accept: 'application/vnd.docker.distribution.manifest.v2+json'}, block_response: block
       rescue SocketError
-        raise DockerRegistry::RegistryUnknownException
+        raise DockerRegistry2::RegistryUnknownException
       rescue RestClient::Unauthorized
-        raise DockerRegistry::RegistryAuthenticationException
+        raise DockerRegistry2::RegistryAuthenticationException
       rescue RestClient::MethodNotAllowed
-        raise DockerRegistry::InvalidMethod
+        raise DockerRegistry2::InvalidMethod
       end
       return response
     end
@@ -148,11 +148,11 @@ class DockerRegistry::Registry
         }
         response = RestClient::Request.execute method: type, url: @base_uri+url, headers: {Authorization: 'Bearer '+token, Accept: 'application/vnd.docker.distribution.manifest.v2+json'}, block_response: block
       rescue SocketError
-        raise DockerRegistry::RegistryUnknownException
+        raise DockerRegistry2::RegistryUnknownException
       rescue RestClient::Unauthorized
-        raise DockerRegistry::RegistryAuthenticationException
+        raise DockerRegistry2::RegistryAuthenticationException
       rescue RestClient::MethodNotAllowed
-        raise DockerRegistry::InvalidMethod
+        raise DockerRegistry2::InvalidMethod
       end
 
       return response
@@ -173,7 +173,7 @@ class DockerRegistry::Registry
         response = RestClient.get uri.to_s, {params: target[:params]}
       rescue RestClient::Unauthorized
         # bad authentication
-        raise DockerRegistry::RegistryAuthenticationException
+        raise DockerRegistry2::RegistryAuthenticationException
       end
       # now save the web token
       return JSON.parse(response)["token"]

--- a/lib/registry/version.rb
+++ b/lib/registry/version.rb
@@ -1,3 +1,3 @@
-module DockerRegistry
-  VERSION = '0.3.0'
+module DockerRegistry2
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
This commit introduces means to avoid name collision
between this gem and docker_registry gem used for
v1 docker registries and index.docker.io.

Both gems introduce class DockerRegistry::Registry which
makes it impossible to use both of them in one program.

This commit renames module DockerRegistry to DockerRegistry2
and moves its definition from docker_registry2.rb to
docker_registry2_ex.rb. In addition this commit introduces
alias DockerRegistry for DockerRegistry2 in file
docker_registry2.rb.

This way, old code benefits from backward compatibility
by requiring docker_registry2.rb and new code can
avoid name collision by requiring docker_registry2_ex.rb.

This patch except new docker_registry2.rb was generated by:

git mv lib/docker_registry2.rb lib/docker_registry2_ex.rb

sed -i -e's/DockerRegistry/DockerRegistry2/g' \
    lib/registry/exceptions.rb \
    lib/registry/registry.rb \
    lib/registry/version.rb \
    lib/docker_registry2_ex.rb \
    README.md \
    docker_registry2.gemspec

Fixes #8 

Signed-off-by: Dmitry Fleytman <dmitry@daynix.com>