### PR TITLE
Add default registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ And execute:
 Once it is installed, you first *open* a connection to a registry, and then *request* from the registry.
 
 ### Connecting
+Use the `connect` method to connect to a registry:
+
+````ruby
+reg = DockerRegistry2.connect("https://my.registy.corp.com")
+````
+
+If you do not provide the URL for a registry, it uses the default `https://registry.hub.docker.com`.
+
+
+
+You can connect anonymously or with credentials:
 
 #### Anonymous
 To connect to a registry:

--- a/lib/docker_registry2.rb
+++ b/lib/docker_registry2.rb
@@ -4,18 +4,18 @@ require File.dirname(__FILE__) + '/registry/exceptions'
 
 
 module DockerRegistry2
-  def self.connect(uri)
+  def self.connect(uri="https://registry.hub.docker.com")
     @reg = DockerRegistry2::Registry.new(uri)
-  end  
-  
+  end
+
   def self.search(query = '')
     @reg.search(query)
   end
 
   def self.tags(repository)
     @reg.tags(repository)
-  end  
-  
+  end
+
   def self.manifest(repository,tag)
     @reg.manifest(repository,tag)
   end

--- a/lib/registry/version.rb
+++ b/lib/registry/version.rb
@@ -1,3 +1,3 @@
 module DockerRegistry2
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end


### PR DESCRIPTION
When no registry is supplied to `DockerRegistry2.connect()`, default to the global https://registry.hub.docker.com
