### PR TITLE
Move ping out of initialize method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 docker_registry2*.gem
+.bundle/*
+Gemfile.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## v1.1.0, 13 October 2017
+
+- Move `ping` call from `DockerRegistry2::Registry.new` to
+  `DockerRegistry2.connect`, to allow a registry to be initialized without a
+  ping.
+

--- a/lib/docker_registry2.rb
+++ b/lib/docker_registry2.rb
@@ -6,6 +6,8 @@ require File.dirname(__FILE__) + '/registry/exceptions'
 module DockerRegistry2
   def self.connect(uri="https://registry.hub.docker.com",opts={})
     @reg = DockerRegistry2::Registry.new(uri,opts)
+    @reg.ping
+    @reg
   end
 
   def self.search(query = '')

--- a/lib/registry/registry.rb
+++ b/lib/registry/registry.rb
@@ -12,8 +12,6 @@ class DockerRegistry2::Registry
     @base_uri = "#{@uri.scheme}://#{@uri.host}:#{@uri.port}"
     @user = options[:user]
     @password = options[:password]
-    # make a ping connection
-    ping
   end
 
   def doget(url)

--- a/lib/registry/version.rb
+++ b/lib/registry/version.rb
@@ -1,3 +1,3 @@
 module DockerRegistry2
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end


### PR DESCRIPTION
Hey @deitch,

Thanks for this gem! It works a treat, and as far as I can tell is still the only client for the registry API.

I've moved the `ping` method out of the `DockerRegistry2::Registry` initialize method and into the `DockerRegistry2.connect` method, because it saves a request for anyone creating a `DockerRegistry2::Registry` instance by hand (and I don't want to spam the registry with unnecessary pings).