### PR TITLE
Add sensible timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.2.0, 15 October 2017
+
+- Add shorter default timeouts. Previously, the RestClient default of 60 seconds
+  was used for both open_timeout and read_timeout. Now, those values are set at
+  2 seconds and 5 seconds, respectively.
+
 ## v1.1.0, 13 October 2017
 
 - Move `ping` call from `DockerRegistry2::Registry.new` to

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This is a simple gem that provides direct http access to a docker registry v2 without going through a docker server. You do **not** requires docker installed on your system to provide access.
+This is a simple gem that provides direct http access to a docker registry v2 without going through a docker server. You do **not** require docker installed on your system to provide access.
 
 ````ruby
 reg = DockerRegistry2.connect("https://my.registy.corp.com")
@@ -46,7 +46,14 @@ reg = DockerRegistry2.connect("https://my.registy.corp.com")
 
 If you do not provide the URL for a registry, it uses the default `https://registry.hub.docker.com`.
 
+By default, requests to the registry will timeout if they take over 2 seconds to
+connect or over 5 seconds to respond. You can set different thresholds when
+connecting to a registry as follows:
 
+```ruby
+opts = { open_timeout: 2, read_timeout: 5 }
+reg = DockerRegistry2.connect("https://my.registy.corp.com", opts)
+```
 
 You can connect anonymously or with credentials:
 

--- a/lib/registry/version.rb
+++ b/lib/registry/version.rb
@@ -1,3 +1,3 @@
 module DockerRegistry2
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
By default, `RestClient` will wait up to 60 seconds to open a connection with a registry. That's a bit long - this PR reduces the time we're willing to wait for a connection to 2 seconds, and the time we're willing to wait for data to 5. Both should be well within normal parameters for a registry, right?