### PR TITLE
Import gemspec into Gemfile (so gem declarations are all in a single place)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,3 @@
 source "https://rubygems.org"
 
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rest-client'
-
-
-group :test do
-  gem 'rake'
-end
+gemspec


### PR DESCRIPTION
This is standard practice for Ruby gems. Means all the declarations are in the gemspec, rather than split between the Gemfile and the gemspec.

(Doesn't need a release - just makes development easier.)