### PR TITLE
New DockerRegistry2::NotFound exceptions

### DIFF
--- a/lib/registry/exceptions.rb
+++ b/lib/registry/exceptions.rb
@@ -21,6 +21,9 @@ module DockerRegistry2
   class UnknownRegistryException < Exception
   end
 
+  class NotFound < Exception
+  end
+
   class InvalidMethod < Exception
   end
 end

--- a/lib/registry/registry.rb
+++ b/lib/registry/registry.rb
@@ -247,6 +247,8 @@ class DockerRegistry2::Registry
         raise DockerRegistry2::RegistryAuthenticationException
       rescue RestClient::MethodNotAllowed
         raise DockerRegistry2::InvalidMethod
+      rescue RestClient::NotFound => error
+        raise DockerRegistry2::NotFound, error
       end
 
       return response

--- a/lib/registry/version.rb
+++ b/lib/registry/version.rb
@@ -1,3 +1,3 @@
 module DockerRegistry2
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end


### PR DESCRIPTION
It's useful for me to catch RestClient::NotFound exceptions here, so probably useful for others too ;)