### PR TITLE
Use DockerRegistry2::NotFound consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v1.3.2, 15 December 2017
+
+- Use DockerRegistry2::NotFound in basic request calls (as well as bearer ones)
+
+## v1.3.1, 15 December 2017
+
+- New DockerRegistry2::NotFound exceptions
+
 ## v1.3.0, 22 October 2017
 
 - Add basic tests

--- a/lib/registry/registry.rb
+++ b/lib/registry/registry.rb
@@ -221,6 +221,8 @@ class DockerRegistry2::Registry
         raise DockerRegistry2::RegistryAuthenticationException
       rescue RestClient::MethodNotAllowed
         raise DockerRegistry2::InvalidMethod
+      rescue RestClient::NotFound => error
+        raise DockerRegistry2::NotFound, error
       end
       return response
     end

--- a/lib/registry/version.rb
+++ b/lib/registry/version.rb
@@ -1,3 +1,3 @@
 module DockerRegistry2
-  VERSION = '1.3.1'
+  VERSION = '1.3.2'
 end


### PR DESCRIPTION
Currently only used in `do_bearer_req`. Should be used in `do_basic_req`, too.

Still loving this library - we use it in Dependabot to help with all our automated Dockerfile updates. :octocat: 