### PR TITLE
Use DockerRegistry2::NotFound in unauthenticated request calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.3.3, 18 December 2017
+
+- Use DockerRegistry2::NotFound in unauthenticated request calls
+
 ## v1.3.2, 15 December 2017
 
 - Use DockerRegistry2::NotFound in basic request calls (as well as bearer ones)

--- a/lib/registry/registry.rb
+++ b/lib/registry/registry.rb
@@ -183,6 +183,8 @@ class DockerRegistry2::Registry
         )
       rescue SocketError
         raise DockerRegistry2::RegistryUnknownException
+      rescue RestClient::NotFound => error
+        raise DockerRegistry2::NotFound, error
       rescue RestClient::Unauthorized => e
         header = e.response.headers[:www_authenticate]
         method = header.downcase.split(' ')[0]
@@ -277,6 +279,8 @@ class DockerRegistry2::Registry
       rescue RestClient::Unauthorized
         # bad authentication
         raise DockerRegistry2::RegistryAuthenticationException
+      rescue RestClient::NotFound => error
+        raise DockerRegistry2::NotFound, error
       end
       # now save the web token
       return JSON.parse(response)["token"]

--- a/lib/registry/version.rb
+++ b/lib/registry/version.rb
@@ -1,3 +1,3 @@
 module DockerRegistry2
-  VERSION = '1.3.2'
+  VERSION = '1.3.3'
 end


### PR DESCRIPTION
I am an idiot and should have done this in 1.3.2. Sorry! This does now cover all places requests are made.