### PR TITLE
Handle 403s when authenticating

### DIFF
--- a/lib/registry/registry.rb
+++ b/lib/registry/registry.rb
@@ -284,7 +284,7 @@ class DockerRegistry2::Registry
           open_timeout: @open_timeout,
           read_timeout: @read_timeout
         )
-      rescue RestClient::Unauthorized
+      rescue RestClient::Unauthorized, RestClient::Forbidden
         # bad authentication
         raise DockerRegistry2::RegistryAuthenticationException
       rescue RestClient::NotFound => error

--- a/lib/registry/version.rb
+++ b/lib/registry/version.rb
@@ -1,3 +1,3 @@
 module DockerRegistry2
-  VERSION = '1.4.0'
+  VERSION = '1.4.1'
 end


### PR DESCRIPTION
Some private registries return 403s when attempting to authenticate without credentials. We should handle this is exactly the same way as 401s.