### PR TITLE
Support OAuth providers that issue token via access_token field

### DIFF
--- a/lib/registry/registry.rb
+++ b/lib/registry/registry.rb
@@ -291,7 +291,8 @@ class DockerRegistry2::Registry
         raise DockerRegistry2::NotFound, error
       end
       # now save the web token
-      return JSON.parse(response)["token"]
+      result = JSON.parse(response)
+      return result["token"] || result["access_token"]
     end
 
     def split_auth_header(header = '')


### PR DESCRIPTION
Hi. I'm trying docker_registry2 with Azure ACR but authentication has been failed because ACR returns token into access_token field instead of token field. (See https://github.com/Azure/acr/blob/master/docs/AAD-OAuth.md#calling-post-oauth2token-to-get-an-acr-access-token-for-helm-repository)

There is no standard spec for naming but both of names are used frequently, so I've added fallback.