### PR TITLE
backwards-compatible default for pagination

### DIFF
--- a/lib/registry/registry.rb
+++ b/lib/registry/registry.rb
@@ -49,15 +49,21 @@ class DockerRegistry2::Registry
     return repos
   end
 
-  def tags(repo,count=100,last="",withHashes = false)
+  def tags(repo,count=nil,last="",withHashes = false)
     #create query params
     params = []
     if last != ""
       params.push(["last",last])
     end
-    params.push(["n",count])
+    if count != nil
+      params.push(["n",count])
+    end
 
-    response = doget "/v2/#{repo}/tags/list?#{URI.encode_www_form(params)}"
+    query_vars = ""
+    if params.length > 0
+      query_vars = "?#{URI.encode_www_form(params)}"
+    end
+    response = doget "/v2/#{repo}/tags/list#{query_vars}"
     # parse the response
     resp = JSON.parse response
     # parse out next page link if necessary

--- a/lib/registry/version.rb
+++ b/lib/registry/version.rb
@@ -1,3 +1,3 @@
 module DockerRegistry2
-  VERSION = '1.6.0'
+  VERSION = '1.6.1'
 end


### PR DESCRIPTION
Resolves the [comment here](https://github.com/deitch/docker_registry2/pull/35#issuecomment-506527834) by @dzunk about the pagination handling breaking backwards compatibility. 