### PR TITLE
Accept application/json (fixes Not Acceptable errors from Artifactory)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.7.1, 13 July 2019
+
+- Add `application/json` to the list of acceptable response formats from
+  registries to fix Artifactory returning 406 Not Acceptable errors when
+  application/vnd.docker.distribution.manifest.v2+json is requested on the tags
+  endpoint
+
 ## v1.7.0, 18 June 2019
 
 - Add `auto_paginate` option to `DockerRegistry2::Registry#tags`. When set to

--- a/lib/registry/registry.rb
+++ b/lib/registry/registry.rb
@@ -367,7 +367,7 @@ class DockerRegistry2::Registry
     def headers(payload: nil, bearer_token: nil)
       headers={}
       headers['Authorization']="Bearer #{bearer_token}" unless bearer_token.nil?
-      headers['Accept']='application/vnd.docker.distribution.manifest.v2+json' if payload.nil?
+      headers['Accept']='application/vnd.docker.distribution.manifest.v2+json, application/json' if payload.nil?
       headers['Content-Type']='application/vnd.docker.distribution.manifest.v2+json' unless payload.nil?
 
       headers

--- a/lib/registry/version.rb
+++ b/lib/registry/version.rb
@@ -1,3 +1,3 @@
 module DockerRegistry2
-  VERSION = '1.7.0'
+  VERSION = '1.7.1'
 end


### PR DESCRIPTION
Add `application/json` to the list of acceptable response formats from registries to fix Artifactory returning 406 Not Acceptable errors when application/vnd.docker.distribution.manifest.v2+json is requested on the tags endpoint.