### PR TITLE
Support passing options for RestClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ opts = { open_timeout: 2, read_timeout: 5 }
 reg = DockerRegistry2.connect("https://my.registy.corp.com", opts)
 ```
 
+Your may pass extra options for RestClient::Request.execute through `http_options` :
+
+```ruby
+opts = { http_options: { proxy: 'http://proxy.example.com:8080/' } }
+reg = DockerRegistry2.connect("https://my.registy.corp.com", opts)
+```
+
 You can connect anonymously or with credentials:
 
 #### Anonymous


### PR DESCRIPTION
It’s not a new feature so much as a generalization of the way we configure the timeouts. This allows users to configure TLS options and proxies on a per-registry basis.

I considered passing any unknown option keyword through to RestClient, but given Registry has special options, I thought we’d better not mix HTTP-related options and Registry-related options together.

Though I wouldn’t specifically encourage overriding RestClient’s timeouts, I chose to keep a full compatiblity with the existing implementation.