### PR TITLE
Remove ping so that proper scope is used.

### DIFF
--- a/lib/docker_registry2.rb
+++ b/lib/docker_registry2.rb
@@ -8,8 +8,6 @@ require File.dirname(__FILE__) + '/registry/blob'
 module DockerRegistry2
   def self.connect(uri="https://registry.hub.docker.com",opts={})
     @reg = DockerRegistry2::Registry.new(uri,opts)
-    @reg.ping
-    @reg
   end
 
   def self.search(query = '')

--- a/lib/registry/registry.rb
+++ b/lib/registry/registry.rb
@@ -38,10 +38,6 @@ class DockerRegistry2::Registry
     return doreq "head", url
   end
 
-  def ping
-    doget '/v2/'
-  end
-
   def search(query = '')
     response = doget "/v2/_catalog"
     # parse the response


### PR DESCRIPTION
With the following code, I was getting auth issues, despite this being a public repository.
```
      reg = DockerRegistry2.connect("https://us.gcr.io")
      pp reg.tags("k8s-artifacts-prod/autoscaling/cluster-autoscaler")
```

The scope wasn't being set due to `ping` not having the request context; removing it entirely fixed it for my use case. Although the tests pass, I do not know for certain if this has negative side effects for other use cases.