### PR TITLE
Fix undefined method error when www_authenticate header is nil

### DIFF
--- a/lib/registry/registry.rb
+++ b/lib/registry/registry.rb
@@ -257,7 +257,7 @@ class DockerRegistry2::Registry
         raise DockerRegistry2::NotFound, error
       rescue RestClient::Unauthorized => e
         header = e.response.headers[:www_authenticate]
-        method = header.downcase.split(' ')[0]
+        method = header.to_s.downcase.split(' ')[0]
         case method
         when 'basic'
           response = do_basic_req(type, url, stream, payload)


### PR DESCRIPTION
If the headers that come back from the registry don't have `www_authenticate` present, as mine didn't, you get 
```
undefined method 'downcase' for nil:NilClass
```
My response didn't have the authenticate key:

```
e.response.headers
=> {:content_type=>"application/json", :docker_distribution_api_version=>"registry/2.0", :date=>"Fri, 24 Jun 2022 18:12:58 GMT", :content_length=>"73", :strict_transport_security=>"max-age=31536000", :docker_ratelimit_source=>"71.232.50.20"}
```

Which blows up on this line:

[e.response.headers[:www_authenticate].downcase.split(' ')[0]
](https://github.com/deitch/docker_registry2/blob/master/lib/registry/registry.rb#L260)

Since .to_s on a nil is '', this tiny PR makes the rest of the logic work when the header is missing.

I had trouble getting the test suite to work locally--I would have liked to add a test. Maybe this is a tiny enough change to be self-evident, though.
