### PR TITLE
Add initial specs for the class methods

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -1,0 +1,31 @@
+name: Specs
+
+on: 
+ pull_request:
+   types: [opened, synchronize, reopened]
+ push:
+   branches:
+     - master
+
+
+jobs:
+  docker:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.7', '3.1']
+        registry-version: ['v1', 'v2']
+    steps:
+    - name: Setup ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: bundle install
+      run: bundle install
+    
+    - name: Run specs
+      run: rspec

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 docker_registry2*.gem
+.rspec_status
 .bundle/*
 Gemfile.lock

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,3 @@
+Metrics/BlockLength:
+  Enabled: false
 inherit_from: .rubocop_todo.yml

--- a/docker_registry2.gemspec
+++ b/docker_registry2.gemspec
@@ -27,7 +27,10 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'rubocop', '>= 0.26.0'
+  spec.add_development_dependency 'vcr', '~> 6'
+  spec.add_development_dependency 'webmock'
 
   spec.add_dependency 'rest-client', '>= 1.8.0'
 end

--- a/spec/docker_registry2_spec.rb
+++ b/spec/docker_registry2_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require_relative '../lib/docker_registry2'
+
+RSpec.describe DockerRegistry2 do
+  let(:connected_object) { described_class.connect('http://localhost:5000') }
+
+  describe '.connect' do
+    it { expect { connected_object }.not_to raise_error }
+    it { expect(connected_object).not_to be_nil }
+  end
+
+  describe '.tags' do
+    let(:tags_hello_world_v1) do
+      VCR.use_cassette('tags/hello-world-v1') { connected_object.tags('hello-world-v1') }
+    end
+    let(:tags_hello_world_v99) do
+      VCR.use_cassette('tags/hello-world-v99') { connected_object.tags('hello-world-v99') }
+    end
+
+    context 'tag exist' do
+      it { expect { tags_hello_world_v1 }.not_to raise_error }
+      it { expect(tags_hello_world_v1).not_to be_nil }
+      it { expect(tags_hello_world_v1.keys).to contain_exactly('tags', 'name') }
+      it { expect(tags_hello_world_v1['tags']).to eq ['latest'] }
+      it { expect(tags_hello_world_v1['name']).to eq 'hello-world-v1' }
+    end
+
+    context 'tag doesnt exist' do
+      it { expect { tags_hello_world_v99 }.to raise_error(DockerRegistry2::NotFound) }
+    end
+  end
+
+  describe 'manifest' do
+    let(:manifest_hello_world_v1_latest) do
+      VCR.use_cassette('manifest/hello-world-v1_latest') { connected_object.manifest('hello-world-v1', 'latest') }
+    end
+
+    let(:manifest_hello_world_v1_non_existent) do
+      VCR.use_cassette('manifest/hello-world-v1_non_existent') do
+        connected_object.manifest('hello-world-v1', 'non_existent')
+      end
+    end
+
+    let(:manifest_hello_world_v99_latest) do
+      VCR.use_cassette('manifest/hello-world-v99_latest') { connected_object.manifest('hello-world-v99', 'latest') }
+    end
+
+    context 'manifest exists' do
+      it { expect { manifest_hello_world_v1_latest }.not_to raise_error }
+    end
+
+    context 'manifest for wrong tag' do
+      it { expect { manifest_hello_world_v1_non_existent }.to raise_error(DockerRegistry2::NotFound) }
+    end
+    context 'manifest for wrong image' do
+      it { expect { manifest_hello_world_v99_latest }.to raise_error(DockerRegistry2::NotFound) }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'webmock/rspec'
+require 'vcr'
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = '.rspec_status'
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/vcr'
+  c.hook_into :webmock
+end

--- a/spec/vcr/manifest/hello-world-v1_latest.yml
+++ b/spec/vcr/manifest/hello-world-v1_latest.yml
@@ -1,0 +1,79 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:5000/v2/hello-world-v1/manifests/latest
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.docker.distribution.manifest.v2+json, application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux x86_64) ruby/3.1.1p18
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - localhost:5000
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '2787'
+      Content-Type:
+      - application/vnd.docker.distribution.manifest.v1+prettyjws
+      Docker-Content-Digest:
+      - sha256:6d28b970d82cb05ce1aca12baddcd72b7034c7e771fdd97d0862672deb863fca
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      Etag:
+      - '"sha256:6d28b970d82cb05ce1aca12baddcd72b7034c7e771fdd97d0862672deb863fca"'
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 08 Dec 2022 12:54:22 GMT
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+           "schemaVersion": 1,
+           "name": "hello-world-v1",
+           "tag": "latest",
+           "architecture": "amd64",
+           "fsLayers": [
+              {
+                 "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+              },
+              {
+                 "blobSum": "sha256:5b0f327be733e58fbaea986eb671ed2eab9bc4a88bda1a7a284209e068d88dc9"
+              }
+           ],
+           "history": [
+              {
+                 "v1Compatibility": "{\"architecture\":\"amd64\",\"config\":{\"Hostname\":\"\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":[\"/hello\"],\"ArgsEscaped\":true,\"Image\":\"sha256:dcb41c36211f527a23dccf9178772996d641d7f5c140dae12ed29411d8ea5e65\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":null},\"container\":\"6f86241dad28350cd4f8cc4e26f857757605e5ccd82dff35802cd9ffd0868274\",\"container_config\":{\"Hostname\":\"6f86241dad28\",\"Domainname\":\"\",\"User\":\"\",\"AttachStdin\":false,\"AttachStdout\":false,\"AttachStderr\":false,\"Tty\":false,\"OpenStdin\":false,\"StdinOnce\":false,\"Env\":[\"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"],\"Cmd\":[\"/bin/sh\",\"-c\",\"#(nop) \",\"CMD [\\\"/hello\\\"]\"],\"ArgsEscaped\":true,\"Image\":\"sha256:dcb41c36211f527a23dccf9178772996d641d7f5c140dae12ed29411d8ea5e65\",\"Volumes\":null,\"WorkingDir\":\"\",\"Entrypoint\":null,\"OnBuild\":null,\"Labels\":{}},\"created\":\"2017-09-12T22:24:11.503356658Z\",\"docker_version\":\"17.06.2-ce\",\"id\":\"bef02f2f646789b5166d68ff91ad4b032b7b626912538d4ba26372d121072f36\",\"os\":\"linux\",\"parent\":\"3619f633e2e68c20001e347ea3b904ded56f5575beb9ac1fc3618d6d2b3a658d\",\"throwaway\":true}"
+              },
+              {
+                 "v1Compatibility": "{\"id\":\"3619f633e2e68c20001e347ea3b904ded56f5575beb9ac1fc3618d6d2b3a658d\",\"created\":\"2017-09-12T22:24:11.330149797Z\",\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) COPY file:b65349dad8105cbef74456e9c0c9da5d001e9eb2ade4b3c21e107909aee5b25a in / \"]}}"
+              }
+           ],
+           "signatures": [
+              {
+                 "header": {
+                    "jwk": {
+                       "crv": "P-256",
+                       "kid": "OJQ5:72OA:ASLQ:4Q7O:AC74:GGYH:TWAE:IPVO:HSUJ:KSJQ:ORWL:CRQI",
+                       "kty": "EC",
+                       "x": "QlC-GjeLyf9lmdVVUZbN8RNKCmWiHHZUN9ToiVUlfsE",
+                       "y": "AE7aunTx-iWgOoQPGFmugLypwngrSmvrAv2-yLM7PnE"
+                    },
+                    "alg": "ES256"
+                 },
+                 "signature": "8mmd4wMOwJkcxuu73AMRrs0RmSGu2E-EJqF1VHxlcnLm9vl_sJ0Ea933t3P5dkgJiVNXRoFDvdQrInyLffa3Ag",
+                 "protected": "eyJmb3JtYXRMZW5ndGgiOjIxNDAsImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAyMi0xMi0wOFQxMjo1NDoyMloifQ"
+              }
+           ]
+        }
+  recorded_at: Thu, 08 Dec 2022 12:54:22 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr/manifest/hello-world-v1_non_existent.yml
+++ b/spec/vcr/manifest/hello-world-v1_non_existent.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:5000/v2/hello-world-v1/manifests/non_existent
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.docker.distribution.manifest.v2+json, application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux x86_64) ruby/3.1.1p18
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - localhost:5000
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 08 Dec 2022 12:55:07 GMT
+      Content-Length:
+      - '102'
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown","detail":{"Tag":"non_existent"}}]}
+
+        '
+  recorded_at: Thu, 08 Dec 2022 12:55:07 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr/manifest/hello-world-v99_latest.yml
+++ b/spec/vcr/manifest/hello-world-v99_latest.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:5000/v2/hello-world-v99/manifests/latest
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.docker.distribution.manifest.v2+json, application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux x86_64) ruby/3.1.1p18
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - localhost:5000
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 08 Dec 2022 12:58:20 GMT
+      Content-Length:
+      - '96'
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown","detail":{"Tag":"latest"}}]}
+
+        '
+  recorded_at: Thu, 08 Dec 2022 12:58:20 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr/tags/hello-world-v1.yml
+++ b/spec/vcr/tags/hello-world-v1.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:5000/v2/hello-world-v1/tags/list
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.docker.distribution.manifest.v2+json, application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux x86_64) ruby/3.1.1p18
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - localhost:5000
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 08 Dec 2022 12:24:41 GMT
+      Content-Length:
+      - '44'
+    body:
+      encoding: UTF-8
+      string: '{"name":"hello-world-v1","tags":["latest"]}
+
+        '
+  recorded_at: Thu, 08 Dec 2022 12:24:41 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr/tags/hello-world-v99.yml
+++ b/spec/vcr/tags/hello-world-v99.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:5000/v2/hello-world-v99/tags/list
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.docker.distribution.manifest.v2+json, application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux x86_64) ruby/3.1.1p18
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - localhost:5000
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 08 Dec 2022 12:48:17 GMT
+      Content-Length:
+      - '123'
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"code":"NAME_UNKNOWN","message":"repository name not known
+        to registry","detail":{"name":"hello-world-v99"}}]}
+
+        '
+  recorded_at: Thu, 08 Dec 2022 12:48:17 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
In this PR I'm adding the specs for the class methods (`.manifest`, `.tags`), following the tests that we have on `test/test.rb`

Note that I'm using [VCR](https://github.com/vcr/vcr) to avoid hitting the registry while running the specs