### PR TITLE
Refactor DockerRegistry2#search

### DIFF
--- a/spec/docker_registry2_spec.rb
+++ b/spec/docker_registry2_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe DockerRegistry2 do
     end
   end
 
+  describe 'search' do
+    let(:search_hello_world) do
+      VCR.use_cassette('search/hello_world') { connected_object.search('hello-world') }
+    end
+    it { expect { search_hello_world }.not_to raise_error }
+    it { expect(search_hello_world.size).to eq 2 }
+  end
+
   describe 'manifest' do
     let(:manifest_hello_world_v1_latest) do
       VCR.use_cassette('manifest/hello-world-v1_latest') { connected_object.manifest('hello-world-v1', 'latest') }

--- a/spec/vcr/search/hello_world.yml
+++ b/spec/vcr/search/hello_world.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:5000/v2/_catalog
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json,
+        application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux x86_64) ruby/3.1.1p18
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - localhost:5000
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Docker-Distribution-Api-Version:
+      - registry/2.0
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Tue, 14 Mar 2023 12:56:29 GMT
+      Content-Length:
+      - '101'
+    body:
+      encoding: UTF-8
+      string: '{"repositories":["hello-world-v1","hello-world-v2","my-ubuntu","my-ubuntu-amd64","my-ubuntu-arm64"]}
+
+        '
+  recorded_at: Tue, 14 Mar 2023 12:56:29 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
In this version of the code, we make use of Ruby's `loop` construct instead of a `while`. We also use a block instead of a yield statement to pass the response object to the caller. We also make use of the `select!` method to filter the repositories array based on the given query, instead of using `find_all` and Regexp. Finally, we use the `match?` method to perform a simple regular expression match on each repository name.

To be sure that the changes are not breaking, I first added the related specs for the `#search` method.