### PR TITLE
Improve search method

### DIFF
--- a/lib/docker_registry2.rb
+++ b/lib/docker_registry2.rb
@@ -11,8 +11,8 @@ module DockerRegistry2
     @reg = DockerRegistry2::Registry.new(uri, opts)
   end
 
-  def self.search(query = '')
-    @reg.search(query)
+  def self.search(query = '', records = 100)
+    @reg.search(query, records)
   end
 
   def self.tags(repository)


### PR DESCRIPTION
Hello @deitch 

I was working in a different project, where we tune the query to the "_catalog" endpoint to get more or less records per page. So I then imagined that we could have the same in the docker_registry2 gem.

So the default is 100 records per page, so thats what i set on the `search` method. I "precompiled" the regex used in the search method, matching the query, outside of the each loop, since it doesnt change. 

Lets see if it works 👍 