### PR TITLE
Fix pagination for tags list pagination for quay.io & registry.access.redhat.com registries

### DIFF
--- a/lib/registry/registry.rb
+++ b/lib/registry/registry.rb
@@ -261,9 +261,7 @@ module DockerRegistry2
       links = parse_link_header(header)
       if links[:next]
         query = URI(links[:next]).query
-        link_key = @uri.host.eql?('quay.io') || @uri.host.eql?('registry.access.redhat.com') ? 'next_page' : 'last'
-        last = URI.decode_www_form(query).to_h[link_key]
-
+        last = URI.decode_www_form(query).to_h['last']
       end
       last
     end


### PR DESCRIPTION
close #106 

Remove special cases for quay.io & registry.access.redhat.com: they were added by #63 and #92, but don't seem necessary anymore:

```
$ curl -Is https://quay.io/v2/keycloak/keycloak/tags/list | grep -i link
link: </v2/keycloak/keycloak/tags/list?n=100&last=23.0.4-0>; rel="next"
```

```
$ curl -Is https://registry.access.redhat.com:443/v2/ubi8/ubi-minimal/tags/list | grep -i link
Link: </v2/ubi8/ubi-minimal/tags/list?n=100&last=8.7-1031-source>; rel="next"
```